### PR TITLE
Add png screenshot into test metadata

### DIFF
--- a/src/AppiumDriver.php
+++ b/src/AppiumDriver.php
@@ -201,7 +201,8 @@ class AppiumDriver extends CodeceptionModule implements
         //$this->debugAppiumDriverLogs();
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignature($test));
         $outputDir = codecept_output_dir();
-        $this->_saveScreenshot($outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
+        $this->_saveScreenshot($report = $outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
+        $test->getMetadata()->addReport('png', $report);
         $this->debug("Screenshot is saved into '$outputDir' dir");
     }
 


### PR DESCRIPTION
It will be automaticaly added in to HTML reports by codeception report generator

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Run suite with broken test and with enabled html report. Html report should contains screenshot

**Test Configuration**:
- PHP Version: 7.1
- Codeception Version: 2.4.1
